### PR TITLE
Allow automatic role selection for cross-account role 

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -32,13 +32,19 @@ func assumeFirstRole(acfg AwsConfig, saml *OktaSamlResponse) (*credentials.Crede
 
 	var arns *SamlProviderArns
 	var found bool = false
+	var err error
 
 	for _, a := range saml.Attributes {
 		if a.Name == "https://aws.amazon.com/SAML/Attributes/Role" {
-			crossAccountArn, err := selectCrossAccount(a.Value)
+			var crossAccountArn string
+			if acfg.CrossAcctArn != "" {
+				crossAccountArn = acfg.CrossAcctArn
+			} else {
+				crossAccountArn, err = selectCrossAccount(a.Value)
 
-			if err != nil {
-				return nil, emptyExpire, err
+				if err != nil {
+					return nil, emptyExpire, err
+				}
 			}
 
 			for _, v := range a.Value {


### PR DESCRIPTION
Follows the source_profile trail in .aws/config:

If a source_profile is specified in the target profile, then we inspect that source_profile to see if a role_arn was set.
If the source_profile has a role_arn set, then we use it as the cross-account role we are trying to find in the list of
values from <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">.

For example, if the configuration is:
```
[default]
region = us-east-1

[profile role1]
source_profile = default
region = us-west-2
role_arn = arn:aws:iam::123456789012:role/cross-account-role-1

[profile role2]
source_profile = role1
region = ap-southeast-2
role_arn = arn:aws:iam::987654321098:role/my-target-role
```

Then when running `oktad role2 -- bash` we will be looking for the role_arn of the source_profile referenced in profile role2,
that is we will try to find arn:aws:iam::123456789012:role/cross-account-role-1 in the values obtained from the SAML assertion.